### PR TITLE
#211: Revise Logo width instance on login view

### DIFF
--- a/src/components/account/Login.tsx
+++ b/src/components/account/Login.tsx
@@ -78,7 +78,7 @@ const OcLoginForm: FunctionComponent<OcLoginFormProps> = ({title = "Sign into yo
         >
           <chakra.form pl={[0, 12]} name="ocLoginForm" onSubmit={handleSubmit}>
             <VStack width="full" alignItems={"flex-start"} gap={4}>
-              <HeaderLogo />
+              <HeaderLogo maxW={250} w="full" />
               <Heading as="h1" fontSize={"4xl"} fontWeight={"thin"} color={loginHeaderColor}>
                 {title}
               </Heading>

--- a/src/components/branding/HeaderLogo.tsx
+++ b/src/components/branding/HeaderLogo.tsx
@@ -5,7 +5,7 @@ import {MyCommerceIcon} from "../icons/Icons"
 interface HeaderLogoProps extends IconProps {}
 export function HeaderLogo({...iconProps}: HeaderLogoProps) {
   return (
-    <Link href="/" height="100%">
+    <Link href="/" display="flex" alignItems="center" height="100%">
       <MyCommerceIcon {...iconProps} />
     </Link>
   )

--- a/src/components/navigation/AcountNavigation.tsx
+++ b/src/components/navigation/AcountNavigation.tsx
@@ -53,9 +53,9 @@ const MobileNavigation = () => {
     currenttheme = cookies.get("currenttheme")
   }
   return (
-    <HStack alignItems="center">
+    <HStack alignItems="center" gap={3}>
       <Menu>
-        <MenuButton pos={"relative"}>
+        <MenuButton pos={"relative"} mr={3}>
           <Icon as={TbInbox} strokeWidth="1.5" fontSize="2xl" />
           <Badge
             display={"flex"}
@@ -115,13 +115,11 @@ const MobileNavigation = () => {
               name={usersToken}
               src={`https://source.unsplash.com/random/?landscape`}
               borderRadius="50%"
-              mr="0"
-              ml="15px"
               size="sm"
               border=".5px solid #ccc"
             />
             <Show above="md">
-              <Text>{usersToken}</Text>
+              <Text whiteSpace="nowrap">{usersToken}</Text>
               <ChevronDownIcon />
             </Show>
           </HStack>


### PR DESCRIPTION
[#211](https://github.com/Sitecore/Sitecore.Commerce.Headstart.ReactAdmin/issues/211)

<img width="505" alt="image" src="https://github.com/xmsandbox/Sitecore.Commerce.Headstart.ReactAdmin.Forrester/assets/18353755/c97013ae-cacc-4483-a331-0c718ebb2197">

- also fixing Menu Button text collapsing + adjusting header spacing
